### PR TITLE
Removes #if DEBUG flags and replaces it with a boolean parameter (#64)

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AppSwizzle (1.3.1)
-  - ReCaptcha/Core (1.4.1)
-  - ReCaptcha/RxSwift (1.4.1):
+  - ReCaptcha/Core (1.4.2)
+  - ReCaptcha/RxSwift (1.4.2):
     - ReCaptcha/Core
     - RxSwift (~> 4.3)
   - RxAtomic (4.4.0)
@@ -36,7 +36,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppSwizzle: db36e436f56110d93e5ae0147683435df593cabc
-  ReCaptcha: 520a707a38dfbb1e5de812aa3c041df60bd31827
+  ReCaptcha: 9a0e1c02a9db9dface31cca63515e28fc3ed6ba8
   RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
   RxBlocking: 138ad53217434444d6eeeb4fb406a45431d92e31
   RxCocoa: df63ebf7b9a70d6b4eeea407ed5dd4efc8979749

--- a/Example/ReCaptcha/ViewController.swift
+++ b/Example/ReCaptcha/ViewController.swift
@@ -108,7 +108,7 @@ class ViewController: UIViewController {
 
     private func setupReCaptcha() {
         // swiftlint:disable:next force_try
-        recaptcha = try! ReCaptcha(endpoint: endpoint, locale: locale)
+		recaptcha = try! ReCaptcha(endpoint: endpoint, locale: locale, useDebugChecks: true)
 
         recaptcha.configureWebView { [weak self] webview in
             webview.frame = self?.view.bounds ?? CGRect.zero

--- a/Example/ReCaptcha_Tests/Core/ReCaptcha__Tests.swift
+++ b/Example/ReCaptcha_Tests/Core/ReCaptcha__Tests.swift
@@ -112,7 +112,7 @@ class ReCaptcha__Tests: XCTestCase {
     }
 
     func test__Force_Visible_Challenge() {
-        let recaptcha = ReCaptcha(manager: ReCaptchaWebViewManager())
+		let recaptcha = ReCaptcha(manager: ReCaptchaWebViewManager(), useDebugChecks: true)
 
         // Initial value
         XCTAssertFalse(recaptcha.forceVisibleChallenge)

--- a/ReCaptcha/Classes/ReCaptcha.swift
+++ b/ReCaptcha/Classes/ReCaptcha.swift
@@ -20,6 +20,8 @@ public class ReCaptcha {
         }
     }
 
+	private let useDebugChecks: Bool
+
     /// The JS API endpoint to be loaded onto the HTML file.
     public enum Endpoint {
         /** Google's default endpoint. Points to
@@ -111,6 +113,7 @@ public class ReCaptcha {
          - baseURL: The base URL sent to the ReCaptcha init
          - infoPlistURL: The base URL retrieved from the application's Info.plist
          - locale: A locale value to translate ReCaptcha into a different language
+         - parameter useDebugChecks: Whether we can use debug methods
      
      Initializes a ReCaptcha object
 
@@ -130,7 +133,8 @@ public class ReCaptcha {
         apiKey: String? = nil,
         baseURL: URL? = nil,
         endpoint: Endpoint = .default,
-        locale: Locale? = nil
+        locale: Locale? = nil,
+        useDebugChecks: Bool = false
     ) throws {
         let infoDict = Bundle.main.infoDictionary
 
@@ -143,17 +147,20 @@ public class ReCaptcha {
             html: config.html,
             apiKey: config.apiKey,
             baseURL: config.baseURL,
-            endpoint: endpoint.getURL(locale: locale)
-        ))
+            endpoint: endpoint.getURL(locale: locale)),
+			useDebugChecks: useDebugChecks
+        )
     }
 
     /**
      - parameter manager: A ReCaptchaWebViewManager instance.
+	 - parameter useDebugChecks: Whether we can use debug methods
 
       Initializes ReCaptcha with the given manager
     */
-    init(manager: ReCaptchaWebViewManager) {
+	init(manager: ReCaptchaWebViewManager, useDebugChecks: Bool = false) {
         self.manager = manager
+		self.useDebugChecks = useDebugChecks
     }
 
     /**
@@ -201,11 +208,14 @@ public class ReCaptcha {
 
     // MARK: - Development
 
-#if DEBUG
     /// Forces the challenge widget to be explicitly displayed.
     public var forceVisibleChallenge: Bool {
         get { return manager.forceVisibleChallenge }
-        set { manager.forceVisibleChallenge = newValue }
+        set {
+			assert(useDebugChecks)
+			manager.forceVisibleChallenge = newValue
+
+		}
     }
 
     /**
@@ -216,10 +226,16 @@ public class ReCaptcha {
      Use only when testing your application.
     */
     public var shouldSkipForTests: Bool {
-        get { return manager.shouldSkipForTests }
-        set { manager.shouldSkipForTests = newValue }
+        get {
+			assert(useDebugChecks)
+			return manager.shouldSkipForTests
+		}
+        set {
+			assert(useDebugChecks)
+			manager.shouldSkipForTests = newValue
+		}
     }
-#endif
+
 }
 
 // MARK: - Private Methods

--- a/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
+++ b/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
@@ -20,7 +20,6 @@ internal class ReCaptchaWebViewManager {
         static let BotUserAgent = "Googlebot/2.1"
     }
 
-#if DEBUG
     /// Forces the challenge to be explicitly displayed.
     var forceVisibleChallenge = false {
         didSet {
@@ -35,7 +34,6 @@ internal class ReCaptchaWebViewManager {
 
     /// Allows validation stubbing for testing
     public var shouldSkipForTests = false
-#endif
 
     /// Sends the result message
     var completion: ((ReCaptchaResult) -> Void)?
@@ -126,12 +124,10 @@ internal class ReCaptchaWebViewManager {
      Starts the challenge validation
      */
      func validate(on view: UIView) {
-#if DEBUG
         guard !shouldSkipForTests else {
             completion?(.token(""))
             return
         }
-#endif
         webView.isHidden = false
         view.addSubview(webView)
 


### PR DESCRIPTION
Addresses issue #64 where Recaptcha's features which were locked behind DEBUG flags could not be set when using Carthage.
