### PR TITLE
Feature: Enable grecaptcha.render optional callback.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AppSwizzle (1.3.1)
-  - ReCaptcha/Core (1.4.2)
-  - ReCaptcha/RxSwift (1.4.2):
+  - ReCaptcha/Core (1.5.0)
+  - ReCaptcha/RxSwift (1.5.0):
     - ReCaptcha/Core
     - RxSwift (~> 5.0)
   - RxBlocking (5.0.0):
@@ -36,7 +36,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppSwizzle: db36e436f56110d93e5ae0147683435df593cabc
-  ReCaptcha: 3f0282f24de3a609ff9698c86f57816145979966
+  ReCaptcha: 74437bda2537832277c769f6e7ff94318d9727e4
   RxBlocking: c67185d26498ea3cbe3e121917c3c16739e43123
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18

--- a/Example/ReCaptcha/ViewController.swift
+++ b/Example/ReCaptcha/ViewController.swift
@@ -65,7 +65,10 @@ class ViewController: UIViewController {
             .subscribe()
             .disposed(by: disposeBag)
 
-        let validate = recaptcha.rx.validate(on: view)
+        let validate = recaptcha.rx.validate(on: view, resetOnError: false)
+            .catchError { error in
+                return .just("Error \(error)")
+            }
             .debug("validate")
             .share()
 

--- a/Example/ReCaptcha_Tests/Core/ReCaptchaDecoder__Tests.swift
+++ b/Example/ReCaptcha_Tests/Core/ReCaptchaDecoder__Tests.swift
@@ -183,4 +183,61 @@ class ReCaptchaDecoder__Tests: XCTestCase {
         // Check
         XCTAssertEqual(result, .error(.failedSetup))
     }
+
+    func test__Decode__Error_Response_Expired() {
+        let exp = expectation(description: "send error")
+        var result: Result?
+
+        assertResult = { res in
+            result = res
+            exp.fulfill()
+        }
+
+        // Send
+        let message = MockMessage(message: ["error": 28])
+        decoder.send(message: message)
+
+        waitForExpectations(timeout: 1)
+
+        // Check
+        XCTAssertEqual(result, .error(.responseExpired))
+    }
+
+    func test__Decode__Error_Render_Failed() {
+        let exp = expectation(description: "send error")
+        var result: Result?
+
+        assertResult = { res in
+            result = res
+            exp.fulfill()
+        }
+
+        // Send
+        let message = MockMessage(message: ["error": 29])
+        decoder.send(message: message)
+
+        waitForExpectations(timeout: 1)
+
+        // Check
+        XCTAssertEqual(result, .error(.failedRender))
+    }
+
+    func test__Decode__Error_Wrong_Format() {
+        let exp = expectation(description: "send error")
+        var result: Result?
+
+        assertResult = { res in
+            result = res
+            exp.fulfill()
+        }
+
+        // Send
+        let message = MockMessage(message: ["error": 26])
+        decoder.send(message: message)
+
+        waitForExpectations(timeout: 1)
+
+        // Check
+        XCTAssertEqual(result, .error(.wrongMessageFormat))
+    }
 }

--- a/Example/ReCaptcha_Tests/Helpers/ReCaptchaError+Equatable.swift
+++ b/Example/ReCaptcha_Tests/Helpers/ReCaptchaError+Equatable.swift
@@ -16,7 +16,9 @@ extension ReCaptchaError: Equatable {
              (.apiKeyNotFound, .apiKeyNotFound),
              (.baseURLNotFound, .baseURLNotFound),
              (.wrongMessageFormat, .wrongMessageFormat),
-             (.failedSetup, .failedSetup):
+             (.failedSetup, .failedSetup),
+             (.responseExpired, .responseExpired),
+             (.failedRender, .failedRender):
             return true
         case (.unexpected(let lhe as NSError), .unexpected(let rhe as NSError)):
             return lhe == rhe
@@ -26,12 +28,14 @@ extension ReCaptchaError: Equatable {
     }
 
     static func random() -> ReCaptchaError {
-        switch arc4random_uniform(5) {
+        switch arc4random_uniform(7) {
         case 0: return .htmlLoadError
         case 1: return .apiKeyNotFound
         case 2: return .baseURLNotFound
         case 3: return .wrongMessageFormat
         case 4: return .failedSetup
+        case 5: return .responseExpired
+        case 6: return .failedRender
         default: return .unexpected(NSError())
         }
     }

--- a/ReCaptcha/Assets/recaptcha.html
+++ b/ReCaptcha/Assets/recaptcha.html
@@ -59,6 +59,14 @@
         post({ token });
         clearObservers();
       },
+      // 'expired-callback': () => {
+      //   post({ error: 28 });
+      //   clearObservers();
+      // },
+      'error-callback': () => {
+        post({ error: 29 });
+        clearObservers();
+      },
       size: 'invisible'
     });
 

--- a/ReCaptcha/Assets/recaptcha.html
+++ b/ReCaptcha/Assets/recaptcha.html
@@ -59,10 +59,10 @@
         post({ token });
         clearObservers();
       },
-      // 'expired-callback': () => {
-      //   post({ error: 28 });
-      //   clearObservers();
-      // },
+      'expired-callback': () => {
+        post({ error: 28 });
+        clearObservers();
+      },
       'error-callback': () => {
         post({ error: 29 });
         clearObservers();

--- a/ReCaptcha/Classes/ReCaptchaDecoder.swift
+++ b/ReCaptcha/Classes/ReCaptchaDecoder.swift
@@ -92,8 +92,8 @@ fileprivate extension ReCaptchaDecoder.Result {
         else if let message = response["log"] as? String {
             return .log(message)
         }
-        else if (response["error"] as? Int) != nil {
-            return .error(.failedSetup)
+        else if let error = response["error"] as? Int {
+            return from(error)
         }
 
         if let action = response["action"] as? String {
@@ -114,5 +114,21 @@ fileprivate extension ReCaptchaDecoder.Result {
         }
 
         return .error(.wrongMessageFormat)
+    }
+
+    private static func from(_ error: Int) -> ReCaptchaDecoder.Result {
+        switch error {
+        case 27:
+            return .error(.failedSetup)
+
+        case 28:
+            return .error(.responseExpired)
+
+        case 29:
+            return .error(.failedRender)
+
+        default:
+            return .error(.wrongMessageFormat)
+        }
     }
 }

--- a/ReCaptcha/Classes/ReCaptchaError.swift
+++ b/ReCaptcha/Classes/ReCaptchaError.swift
@@ -28,6 +28,12 @@ public enum ReCaptchaError: Error, CustomStringConvertible {
     /// ReCaptcha setup failed
     case failedSetup
 
+    /// ReCaptcha response expired
+    case responseExpired
+
+    /// ReCaptcha render failed
+    case failedRender
+
     /// A human-readable description for each error
     public var description: String {
         switch self {
@@ -53,6 +59,12 @@ public enum ReCaptchaError: Error, CustomStringConvertible {
             Also check that you're using ReCaptcha's **SITE KEY** for client side integration.
             """
             // swiftlint:enable line_length
+
+        case .responseExpired:
+            return "Response expired and need to re-verify"
+
+        case .failedRender:
+            return "Recaptha encountered an error in execution"
         }
     }
 }


### PR DESCRIPTION
I'd like to introduce following optional callbacks of `grecaptcha.render`.
- `expired-callback`
- `error-callback`

cf. https://developers.google.com/recaptcha/docs/invisible

Currently, when the connectivity is lost after starting recaptcha sequence, there is no way to know the hanging.
`error-callback` is called when a connectivity issue happens, and the result should be error.