### PR TITLE
Feature: Give access to the `forceVisibleChallenge` flag in any configuration

### DIFF
--- a/ReCaptcha/Classes/ReCaptcha.swift
+++ b/ReCaptcha/Classes/ReCaptcha.swift
@@ -211,15 +211,15 @@ public class ReCaptcha {
         manager.onDidFinishLoading = closure
     }
 
-    // MARK: - Development
-
-#if DEBUG
-    /// Forces the challenge widget to be explicitly displayed.
+    /// Forces the challenge widget to be explicitly displayed. Default is `false`.
     public var forceVisibleChallenge: Bool {
         get { return manager.forceVisibleChallenge }
         set { manager.forceVisibleChallenge = newValue }
     }
 
+    // MARK: - Development
+
+#if DEBUG
     /**
      Allows validation stubbing for testing
 

--- a/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
+++ b/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
@@ -24,7 +24,6 @@ internal class ReCaptchaWebViewManager {
         static let BotUserAgent = "Googlebot/2.1"
     }
 
-#if DEBUG
     /// Forces the challenge to be explicitly displayed.
     var forceVisibleChallenge = false {
         didSet {
@@ -37,6 +36,7 @@ internal class ReCaptchaWebViewManager {
         }
     }
 
+#if DEBUG
     /// Allows validation stubbing for testing
     public var shouldSkipForTests = false
 #endif


### PR DESCRIPTION
Currently, we can only use this flag if we have the `DEBUG` compilation flag
This flag is useful to test the Captcha feature, even in a configuration different from `DEBUG`.
It is useful to let the user choose to enable or disable this flag based on the Bool value and not on the project configuration.
