### PR TITLE
Set didFinishLoading before attempting to execute Javascript

### DIFF
--- a/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
+++ b/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
@@ -154,8 +154,8 @@ internal class ReCaptchaWebViewManager {
      */
     func reset() {
         configureWebViewDispatchToken = UUID()
-        executeJS(command: .reset)
         didFinishLoading = false
+        executeJS(command: .reset)
     }
 }
 


### PR DESCRIPTION
Maybe I'm wrong, I don't think the Javascript is ever executed unless `didFinishLoading` is set before calling `executeJS(command: reset)`. We see a few errors and we end up in a never ending loop. 

`didFinishLoading` is only set `true` if the Javascript succeed, but if there is an error the reset is never called since `executeJS` checks `executeJS` before continuing. https://github.com/fjcaetano/ReCaptcha/blob/master/ReCaptcha/Classes/ReCaptchaWebViewManager.swift#L245