### PR TITLE
#107: Swift Package Manager support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ fastlane/test_output
 
 ## VS Code
 .vscode
+
+## Swift Package Manager
+Packages/
+Package.pins
+Package.resolved
+.swiftpm
+.build/

--- a/Example/ReCaptcha_Tests/Core/ReCaptcha__Tests.swift
+++ b/Example/ReCaptcha_Tests/Core/ReCaptcha__Tests.swift
@@ -8,9 +8,8 @@
 
 import AppSwizzle
 @testable import ReCaptcha
-import RxSwift
-import XCTest
 
+import XCTest
 
 class ReCaptcha__Tests: XCTestCase {
     fileprivate struct Constants {

--- a/Example/ReCaptcha_Tests/RxSwift/ReCaptcha+Rx__Tests.swift
+++ b/Example/ReCaptcha_Tests/RxSwift/ReCaptcha+Rx__Tests.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018 ReCaptcha. All rights reserved.
 //
 
+#if canImport(RxSwift) && canImport(RxBlocking) && canImport(RxSwift)
+
 @testable import ReCaptcha
 
 import RxBlocking
@@ -263,3 +265,5 @@ class ReCaptcha_Rx__Tests: XCTestCase {
         }
     }
 }
+
+#endif

--- a/Example/ReCaptcha_Tests/RxSwift/ReCaptcha+Rx__Tests.swift
+++ b/Example/ReCaptcha_Tests/RxSwift/ReCaptcha+Rx__Tests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 ReCaptcha. All rights reserved.
 //
 
-#if canImport(RxSwift) && canImport(RxBlocking) && canImport(RxSwift)
+#if canImport(RxSwift) && canImport(RxBlocking) && canImport(RxCocoa)
 
 @testable import ReCaptcha
 

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0"),
-		.package(url: "https://github.com/JakubMazur/AppSwizzle.git", from: "1.3.2"),
+		.package(url: "https://github.com/JakubMazur/AppSwizzle.git", from: "1.3.2")
 	],
 	targets: [
 		.target(
@@ -49,4 +49,3 @@ let package = Package(
 			])
 	]
 )
-

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0"),
-		.package(url: "https://github.com/JakubMazur/AppSwizzle.git", from: "1.3.2")
+		.package(url: "https://github.com/JakubMazur/AppSwizzle.git", from: "1.3.3")
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,11 @@ let package = Package(
 		.target(
 			name: "ReCaptcha",
 			dependencies: [],
-			path: "ReCaptcha/Classes",
-			exclude: ["Rx"],
+			path: "ReCaptcha",
+			exclude: ["Classes/Rx"],
+			resources: [
+				.process("Assets/recaptcha.html")
+			],
 			linkerSettings: [
 				.linkedFramework("UIKit")
 			]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+	name: "ReCaptcha",
+	platforms: [
+		.iOS(.v9)
+	],
+	products: [
+		.library(
+			name: "ReCaptcha",
+			targets: ["ReCaptcha"]),
+		.library(
+			name: "ReCaptchaRx",
+			targets: ["ReCaptchaRx"])
+	],
+	dependencies: [
+		.package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0"),
+		.package(url: "https://github.com/JakubMazur/AppSwizzle.git", from: "1.3.2"),
+	],
+	targets: [
+		.target(
+			name: "ReCaptcha",
+			dependencies: [],
+			path: "ReCaptcha/Classes",
+			exclude: ["Rx"],
+			linkerSettings: [
+				.linkedFramework("UIKit")
+			]
+		),
+		.target(
+			name: "ReCaptchaRx",
+			dependencies: [
+				"ReCaptcha", "RxSwift"
+			],
+			path: "ReCaptcha/Classes/Rx",
+			linkerSettings: [
+				.linkedFramework("UIKit")
+			]),
+		.testTarget(
+			name: "ReCaptcha_Tests",
+			dependencies: ["ReCaptcha", "AppSwizzle"],
+			path: "Example/ReCaptcha_Tests",
+			exclude: ["Info.plist"],
+			resources: [
+				.copy("mock.html")
+			])
+	]
+)
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,17 @@ pod "ReCaptcha"
 pod "ReCaptcha/RxSwift"
 ```
 
+#### Swift Package Manager
+
+```swift
+https://github.com/fjcaetano/ReCaptcha
+```
+
+Adding this in project dependency in Xcode will show option to add `ReCaptcha` and `ReCaptchaRx`, the latter containing 
+internal dependency for ReCaptcha framework.
+
 #### Carthage
+
 ``` ruby
 github "fjcaetano/ReCaptcha"
 ```

--- a/ReCaptcha/Classes/ReCaptcha.swift
+++ b/ReCaptcha/Classes/ReCaptcha.swift
@@ -55,16 +55,7 @@ public class ReCaptcha {
         let baseURL: URL
 
         /// The Bundle that holds ReCaptcha's assets
-        private static let bundle: Bundle = {
-            let bundle = Bundle(for: ReCaptcha.self)
-            guard let cocoapodsBundle = bundle
-                .path(forResource: "ReCaptcha", ofType: "bundle")
-                .flatMap(Bundle.init(path:)) else {
-                    return bundle
-            }
-
-            return cocoapodsBundle
-        }()
+		private static let bundle: Bundle = Bundle.module
 
         /**
          - parameters:

--- a/ReCaptcha/Classes/Rx/SPM_exported.swift
+++ b/ReCaptcha/Classes/Rx/SPM_exported.swift
@@ -1,0 +1,16 @@
+//
+//  SPM_exported.swift
+//  
+//
+//  Created by Jakub Mazur on 15/07/2021.
+//
+
+/*
+
+Since Swift Package Manager have directory structure and folders cannot override this is needed to use internal dependency in ReCaptcha+Rx.swift file.
+
+This file should NOT be included in Cocoapods and Carthage build
+
+*/
+
+@_exported import ReCaptcha

--- a/ReCaptcha/Classes/Rx/SPM_exported.swift
+++ b/ReCaptcha/Classes/Rx/SPM_exported.swift
@@ -7,7 +7,8 @@
 
 /*
 
-Since Swift Package Manager have directory structure and folders cannot override this is needed to use internal dependency in ReCaptcha+Rx.swift file.
+Since Swift Package Manager have directory structure and folders cannot override
+this module import is needed to use internal dependency in ReCaptcha+Rx.swift file.
 
 This file should NOT be included in Cocoapods and Carthage build
 


### PR DESCRIPTION
### Swift Package Manager Support #107

Swift Package Manager added to both `Rx` and main target. 

- [x] check `pod spec lint` 
- [x] check `carhage build --archive`
- [x] `swift build` for iOS target
- [x] update installation README

#### Known issues:

1. `AppSwizzle` that frameworks is using as test target does not support SPM yet. I open [PR](https://github.com/zixun/AppSwizzle/pull/3) with support to SPM there, but project looks abandoned. SPM test target has then dependency to my fork of this project with SPM Support
2. Currently SPM has a limitation that will resolve all dependencies that Package incudes for any target (not test target) described [here as partialy implemented](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md). There is no negative impact on a project exept the fact that the user that is not using `Rx` version will see resolved package in Xcode **that will not be linked to a binary later or usable in a project**. [Here is my StackOverflow question](https://stackoverflow.com/questions/68408989/swift-package-manager-target-based-dependency) on this topic that leads me to open ticket [SR-8658](https://bugs.swift.org/browse/SR-8658). AFAIK there is no walkaround for it.

#### TODO:

#108: after merge and tag a new version update a package to Swift Package Index
