### PR TITLE
Fix default copyright refs

### DIFF
--- a/ReCaptcha/Classes/DispatchQueue+Throttle.swift
+++ b/ReCaptcha/Classes/DispatchQueue+Throttle.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 21/12/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/ReCaptcha.swift
+++ b/ReCaptcha/Classes/ReCaptcha.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 22/03/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/ReCaptchaDecoder.swift
+++ b/ReCaptcha/Classes/ReCaptchaDecoder.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 22/03/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/ReCaptchaError.swift
+++ b/ReCaptcha/Classes/ReCaptchaError.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 22/03/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/ReCaptchaResult.swift
+++ b/ReCaptcha/Classes/ReCaptchaResult.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 06/03/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
+++ b/ReCaptcha/Classes/ReCaptchaWebViewManager.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 22/03/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation

--- a/ReCaptcha/Classes/String+Dict.swift
+++ b/ReCaptcha/Classes/String+Dict.swift
@@ -3,7 +3,7 @@
 //  ReCaptcha
 //
 //  Created by Flávio Caetano on 10/10/17.
-//  Copyright © 2018 ReCaptcha. All rights reserved.
+//  Copyright © 2018 ReCaptcha, MIT License.
 //
 
 import Foundation


### PR DESCRIPTION
Looks like a few files had an editor-default reference inserted. Updated them to agree with the overall project license for clarity. (CC @fjcaetano)